### PR TITLE
Keep SVG accent colors, reduce idle to 10s, fullscreen PWA on iPhone

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,13 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
     <title>HTMHELLPAD</title>
     <link rel="stylesheet" href="styles.css">
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#000000">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">

--- a/scripts.js
+++ b/scripts.js
@@ -3,7 +3,7 @@
 
     // --- Constants ---
     var ERROR_DURATION = 1000;
-    var IDLE_TIMEOUT = 30000;
+    var IDLE_TIMEOUT = 10000;
 
     // --- Boot sequence (weight = relative display time) ---
     var BOOT_LINES = [

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "htmhellpad-v1";
+const CACHE_NAME = "htmhellpad-v2";
 
 const PRECACHE_ASSETS = [
     './',

--- a/styles.css
+++ b/styles.css
@@ -48,7 +48,7 @@ body {
     width: 100vw;
     height: 100vh;
     background: #000000;
-    padding: 16px;
+    padding: max(16px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right)) max(16px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
     overflow: hidden;
     display: flex;
     flex-direction: column;
@@ -91,6 +91,8 @@ body {
     justify-content: space-between;
     position: relative;
     overflow: hidden;
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
 }
 
 /* Blueprint grid */
@@ -136,11 +138,11 @@ body {
 }
 
 .welcome-line-top {
-    margin-top: 24px;
+    margin-top: max(24px, env(safe-area-inset-top));
 }
 
 .welcome-line-bottom {
-    margin-bottom: 24px;
+    margin-bottom: max(24px, env(safe-area-inset-bottom));
 }
 
 .welcome-content {
@@ -241,6 +243,8 @@ body {
     background:
         radial-gradient(ellipse at center, #123d6e 0%, #0a2540 50%, #041520 100%);
     animation: app-reveal 0.6s ease-out forwards;
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
 }
 
 @keyframes app-reveal {
@@ -267,11 +271,11 @@ body {
 }
 
 .app-line-top {
-    margin-top: 24px;
+    margin-top: max(24px, env(safe-area-inset-top));
 }
 
 .app-line-bottom {
-    margin-bottom: 24px;
+    margin-bottom: max(24px, env(safe-area-inset-bottom));
 }
 
 /* --- App header (logo + sequence) --- */
@@ -528,7 +532,6 @@ body {
 #stratagem-logo {
     width: 160px;
     height: 160px;
-    filter: brightness(0) invert(1);
 }
 
 #stratagem-name {


### PR DESCRIPTION
- Remove brightness(0) invert(1) filter on #stratagem-logo to preserve
  original SVG accent colors (#49adc9 blue, #de7b6c red)
- Reduce idle screensaver timeout from 30s to 10s
- Add viewport-fit=cover and black-translucent status bar style for
  fullscreen PWA coverage over Dynamic Island on iPhone
- Add safe-area-inset padding to all screens for proper content insets
- Bump service worker cache version to v2